### PR TITLE
Remove deletion protection from db instances.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.12.3"
+  required_version = ">=1.1"
 }
 
 # Look up the primary VPC

--- a/main.tf
+++ b/main.tf
@@ -41,11 +41,7 @@ resource "aws_rds_cluster" "aurora_cluster" {
   }
 }
 
-# why are there two instance blocks you might ask?
-# well Timmy that's because Terraform parses and handles variables before interpolations can be processed
-# dont ask me, I didn't design Terraform, and am not smart enough to anyways. 
-# look here for more context: https://github.com/hashicorp/terraform/issues/10730
-resource "aws_rds_cluster_instance" "aurora_db_delete" {
+resource "aws_rds_cluster_instance" "aurora_db" {
   count              = var.deletion_protection ? 0 : var.db_instance_count
   identifier         = "${var.db_name}-instance-${count.index + 1}"
   cluster_identifier = aws_rds_cluster.aurora_cluster.cluster_identifier
@@ -66,23 +62,12 @@ resource "aws_rds_cluster_instance" "aurora_db_delete" {
   }
 }
 
-resource "aws_rds_cluster_instance" "aurora_db_no_delete" {
-  count              = var.deletion_protection ? var.db_instance_count : 0
-  identifier         = "${var.db_name}-instance-${count.index + 1}"
-  cluster_identifier = aws_rds_cluster.aurora_cluster.cluster_identifier
+moved {
+  from = aws_rds_cluster_instance.aurora_db_delete
+  to   = aws_rds_cluster_instance.aurora_db
+}
 
-  publicly_accessible = false
-
-  engine_version = var.engine_version
-  engine         = var.engine
-
-  db_subnet_group_name = aws_db_subnet_group.rds_subnet_group.name
-  instance_class       = var.db_instance_class
-
-  performance_insights_enabled = var.performance_insights_enabled
-
-  lifecycle {
-    prevent_destroy = true
-    ignore_changes  = [engine_version]
-  }
+moved {
+  from = aws_rds_cluster_instance.aurora_db_no_delete
+  to   = aws_rds_cluster_instance.aurora_db
 }

--- a/main.tf
+++ b/main.tf
@@ -61,13 +61,3 @@ resource "aws_rds_cluster_instance" "aurora_db" {
     ignore_changes  = [engine_version]
   }
 }
-
-moved {
-  from = aws_rds_cluster_instance.aurora_db_delete
-  to   = aws_rds_cluster_instance.aurora_db
-}
-
-moved {
-  from = aws_rds_cluster_instance.aurora_db_no_delete
-  to   = aws_rds_cluster_instance.aurora_db
-}

--- a/rename.tf
+++ b/rename.tf
@@ -1,0 +1,11 @@
+# Renames the old "deletable" instance resource name to the new instance resource name
+moved {
+  from = aws_rds_cluster_instance.aurora_db_delete
+  to   = aws_rds_cluster_instance.aurora_db
+}
+
+# Renames the old "undeletable" instance resource name to the new instance resource name
+moved {
+  from = aws_rds_cluster_instance.aurora_db_no_delete
+  to   = aws_rds_cluster_instance.aurora_db
+}


### PR DESCRIPTION
The deletion protection being used to set lifecycle `prevent_destroy` puts your database into a state where you cannot terraform it if a terraform change would require recycling a db instance. Since it's generally okay to delete db instances (but not clusters) this just caused more headache than it was worth.